### PR TITLE
Add article fixtures, wire up edit article tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -263,6 +263,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -538,6 +539,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
       "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/src/common/testData/generateNewArticleData.js
+++ b/src/common/testData/generateNewArticleData.js
@@ -10,5 +10,7 @@ export function generateNewArticleData(logger, tagNumber = 0) {
     tags,
   };
 
+  logger.debug(`New article generated: ${JSON.stringify(article)}`);
+
   return article;
 }

--- a/src/common/testData/generateNewArticleData.js
+++ b/src/common/testData/generateNewArticleData.js
@@ -10,7 +10,6 @@ export function generateNewArticleData(logger, tagNumber = 0) {
     tags,
   };
 
-  logger.debug(`New article generated: ${JSON.stringify(article)}`);
-
+  logger.debug(`New article generated: ${article}`);
   return article;
 }

--- a/src/ui/pages/article/CreateArticlePage.js
+++ b/src/ui/pages/article/CreateArticlePage.js
@@ -9,7 +9,27 @@ export class CreateArticlePage {
     this.publishArticleButton = page.getByRole('button', {
       name: 'Publish Article',
     });
+    this.updateArticleButton = page.getByRole('button', {
+      name: 'Update Article',
+    });
     this.errorMessage = page.getByRole('list').nth(1);
+    this.tagsField = page.getByPlaceholder('Enter tags');
+  }
+
+  async waitForFormToBePrefilled() {
+    await test.step(`Wait for the article form to be pre-filled`, async () => {
+      await expect(this.titleField).not.toHaveValue('');
+    });
+  }
+
+  async addTags(tags) {
+    await test.step(`Add tags: ${tags.join(', ')}`, async () => {
+      for (const tag of tags) {
+        await this.tagsField.fill(tag);
+        await this.tagsField.press('Enter');
+        await expect(this.tagsField).toHaveValue('');
+      }
+    });
   }
 
   async fillTitleField(title) {
@@ -33,6 +53,24 @@ export class CreateArticlePage {
   async clickPublishArticleButton() {
     await test.step(`Click the 'Publish Article' button`, async () => {
       await this.publishArticleButton.click();
+    });
+  }
+
+  async clickUpdateArticleButton() {
+    await test.step(`Click the 'Update Article' button`, async () => {
+      const [response] = await Promise.all([
+        this.page.waitForResponse(
+          (res) =>
+            res.url().includes('/api/articles/') &&
+            res.request().method() === 'PUT',
+        ),
+        this.updateArticleButton.click(),
+      ]);
+
+      expect(response.ok()).toBeTruthy();
+
+      await this.page.waitForURL((url) => !url.pathname.includes('/editor/'));
+      await this.page.reload();
     });
   }
 

--- a/src/ui/pages/article/ViewArticlePage.js
+++ b/src/ui/pages/article/ViewArticlePage.js
@@ -4,6 +4,14 @@ export class ViewArticlePage {
   constructor(page) {
     this.page = page;
     this.articleTitleHeader = page.getByRole('heading');
+     this.editArticleLink = page.getByRole(
+      'link', { name: 'Edit Article' }).first();
+  }
+
+  async clickEditArticleLink() {
+    await test.step(`Click the 'Edit Article' link`, async () => {
+      await this.editArticleLink.click();
+    });
   }
 
   async assertArticleTitleIsVisible(title) {

--- a/tests/_fixtures/fixtures.ts
+++ b/tests/_fixtures/fixtures.ts
@@ -1,5 +1,6 @@
 import { mergeTests } from '@playwright/test';
 import { test as authTest } from './fixturesAuth';
 import { test as genericTest } from './fixturesGeneric';
+import { test as articlesTest } from './fixturesArticles';
 
-export const test = mergeTests(authTest, genericTest);
+export const test = mergeTests(authTest, genericTest, articlesTest);

--- a/tests/_fixtures/fixturesArticles.ts
+++ b/tests/_fixtures/fixturesArticles.ts
@@ -1,0 +1,45 @@
+import { test as genericTest } from './fixturesGeneric';
+import { CreateArticlePage } from '../../src/ui/pages/article/CreateArticlePage';
+import { ViewArticlePage } from '../../src/ui/pages/article/ViewArticlePage';
+import { EditArticlePage } from '../../src/ui/pages/article/EditArticlePage';
+import { generateNewArticleData } from '../../src/common/testData/generateNewArticleData';
+
+export const test = genericTest.extend<{
+  createArticlePage;
+  viewArticlePage;
+  editArticlePage;
+  articleWithoutTags;
+  articleWithOneTag;
+  articleWithTwoTags;
+}>({
+  createArticlePage: async ({ page }, use) => {
+    const createArticlePage = new CreateArticlePage(page);
+
+    await use(createArticlePage);
+  },
+  viewArticlePage: async ({ page }, use) => {
+    const viewArticlePage = new ViewArticlePage(page);
+
+    await use(viewArticlePage);
+  },
+  editArticlePage: async ({ page }, use) => {
+    const editArticlePage = new EditArticlePage(page);
+
+    await use(editArticlePage);
+  },
+  articleWithoutTags: async ({ logger }, use) => {
+    const article = generateNewArticleData(logger);
+
+    await use(article);
+  },
+  articleWithOneTag: async ({ logger }, use) => {
+    const article = generateNewArticleData(logger, 1);
+
+    await use(article);
+  },
+  articleWithTwoTags: async ({ logger }, use) => {
+    const article = generateNewArticleData(logger, 2);
+
+    await use(article);
+  },
+});

--- a/tests/_fixtures/fixturesGeneric.ts
+++ b/tests/_fixtures/fixturesGeneric.ts
@@ -18,7 +18,7 @@ export const test = base.extend<
   },
   logger: [
     async ({}, use) => {
-      const logger = new Logger('error');
+      const logger = new Logger('debug');
 
       await use(logger);
     },

--- a/tests/createArticle/createArticleWithRequiredFields.spec.js
+++ b/tests/createArticle/createArticleWithRequiredFields.spec.js
@@ -1,29 +1,23 @@
 import { test } from '../_fixtures/fixtures';
-import { CreateArticlePage } from '../../src/ui/pages/article/CreateArticlePage';
-import { generateNewArticleData } from '../../src/common/testData/generateNewArticleData';
 import { signUpUser } from '../../src/ui/actions/auth/signUpUser';
-import { ViewArticlePage } from '../../src/ui/pages/article/ViewArticlePage';
 
-let createArticlePage;
-let viewArticlePage;
-let article;
-
-test.beforeEach(async ({ page, user, logger }) => {
-  createArticlePage = new CreateArticlePage(page);
-  viewArticlePage = new ViewArticlePage(page);
-  article = generateNewArticleData(logger);
-
+test.beforeEach(async ({ page, user }) => {
   await signUpUser(page, user);
 });
 
-test('Creat an article with required fields', async ({ homePage }) => {
+test('Create an article with required fields', async ({
+  homePage,
+  createArticlePage,
+  viewArticlePage,
+  articleWithoutTags,
+}) => {
   await homePage.clickNewArticleLink();
 
-  await createArticlePage.fillTitleField(article.title);
-  await createArticlePage.fillDescriptionField(article.description);
-  await createArticlePage.fillTextField(article.text);
+  await createArticlePage.fillTitleField(articleWithoutTags.title);
+  await createArticlePage.fillDescriptionField(articleWithoutTags.description);
+  await createArticlePage.fillTextField(articleWithoutTags.text);
   await createArticlePage.clickPublishArticleButton();
 
-  await viewArticlePage.assertArticleTitleIsVisible(article.title);
-  await viewArticlePage.assertArticleTextIsVisible(article.text);
+  await viewArticlePage.assertArticleTitleIsVisible(articleWithoutTags.title);
+  await viewArticlePage.assertArticleTextIsVisible(articleWithoutTags.text);
 });

--- a/tests/createArticle/createArticleWithoutRequiredFields.spec.js
+++ b/tests/createArticle/createArticleWithoutRequiredFields.spec.js
@@ -1,17 +1,15 @@
 import { test } from '../_fixtures/fixtures';
-import { CreateArticlePage } from '../../src/ui/pages/article/CreateArticlePage';
 import { signUpUser } from '../../src/ui/actions/auth/signUpUser';
 import { TITLE_CANNOT_BE_EMPTY } from '../../src/ui/constants/articleErrorMessages';
 
-let createArticlePage;
-
 test.beforeEach(async ({ page, user }) => {
-  createArticlePage = new CreateArticlePage(page);
-
   await signUpUser(page, user);
 });
 
-test('Creat an article without required fields', async ({ homePage }) => {
+test('Create an article without required fields', async ({
+  homePage,
+  createArticlePage,
+}) => {
   await homePage.clickNewArticleLink();
 
   await createArticlePage.clickPublishArticleButton();

--- a/tests/editArticle/editArticle.spec.js
+++ b/tests/editArticle/editArticle.spec.js
@@ -1,0 +1,81 @@
+import { test } from '../_fixtures/fixtures';
+import { signUpUser } from '../../src/ui/actions/auth/signUpUser';
+
+test.beforeEach(
+  async ({
+    page,
+    user,
+    homePage,
+    createArticlePage,
+    viewArticlePage,
+    articleWithoutTags,
+  }) => {
+    await signUpUser(page, user);
+
+    await homePage.clickNewArticleLink();
+    await createArticlePage.fillTitleField(articleWithoutTags.title);
+    await createArticlePage.fillDescriptionField(
+      articleWithoutTags.description,
+    );
+    await createArticlePage.fillTextField(articleWithoutTags.text);
+    await createArticlePage.clickPublishArticleButton();
+
+    await viewArticlePage.assertArticleTitleIsVisible(articleWithoutTags.title);
+  },
+);
+
+test('Edit an article without tags', async ({
+  viewArticlePage,
+  createArticlePage,
+  editArticlePage,
+  articleWithoutTags,
+}) => {
+  await viewArticlePage.clickEditArticleLink();
+  await createArticlePage.waitForFormToBePrefilled();
+
+  await createArticlePage.fillTitleField(articleWithoutTags.title);
+  await createArticlePage.fillDescriptionField(articleWithoutTags.description);
+  await createArticlePage.fillTextField(articleWithoutTags.text);
+  await createArticlePage.clickUpdateArticleButton();
+
+  await editArticlePage.assertArticleTitle(articleWithoutTags.title);
+  await editArticlePage.assertArticleText(articleWithoutTags.text);
+});
+
+test('Edit an article with one tag', async ({
+  viewArticlePage,
+  createArticlePage,
+  editArticlePage,
+  articleWithOneTag,
+}) => {
+  await viewArticlePage.clickEditArticleLink();
+  await createArticlePage.waitForFormToBePrefilled();
+
+  await createArticlePage.addTags(articleWithOneTag.tags);
+  await createArticlePage.fillTitleField(articleWithOneTag.title);
+  await createArticlePage.fillDescriptionField(articleWithOneTag.description);
+  await createArticlePage.fillTextField(articleWithOneTag.text);
+  await createArticlePage.clickUpdateArticleButton();
+
+  await editArticlePage.assertArticleTitle(articleWithOneTag.title);
+  await editArticlePage.assertArticleText(articleWithOneTag.text);
+});
+
+test('Edit an article with two tags', async ({
+  viewArticlePage,
+  createArticlePage,
+  editArticlePage,
+  articleWithTwoTags,
+}) => {
+  await viewArticlePage.clickEditArticleLink();
+  await createArticlePage.waitForFormToBePrefilled();
+
+  await createArticlePage.addTags(articleWithTwoTags.tags);
+  await createArticlePage.fillTitleField(articleWithTwoTags.title);
+  await createArticlePage.fillDescriptionField(articleWithTwoTags.description);
+  await createArticlePage.fillTextField(articleWithTwoTags.text);
+  await createArticlePage.clickUpdateArticleButton();
+
+  await editArticlePage.assertArticleTitle(articleWithTwoTags.title);
+  await editArticlePage.assertArticleText(articleWithTwoTags.text);
+});


### PR DESCRIPTION
Added fixturesArticles.ts with createArticlePage, viewArticlePage, editArticlePage, articleWithoutTags, articleWithOneTag, articleWithTwoTags fixtures, merged into fixtures.ts. Added debug logging to generateNewArticleData.js. Rewired create/edit article tests to use the new fixtures.